### PR TITLE
Use "mono8" for mask and swap brg to rgb

### DIFF
--- a/python/object_recognition_capture/openni_capture.py
+++ b/python/object_recognition_capture/openni_capture.py
@@ -142,8 +142,8 @@ def create_capture_plasm(bag_name, angle_thresh, segmentation_cell, n_desired=72
                pose_filter['R', 'T'] >> poseMsg['R', 'T'] ]
 
     # publish the source data
-    rgbMsg = Mat2Image(frame_id='/camera_rgb_optical_frame', swap_rgb=True, encoding='bgr8')
-    depthMsg = Mat2Image(frame_id='/camera_rgb_optical_frame', encoding='16UC1')
+    rgbMsg = Mat2Image(frame_id='/camera_rgb_optical_frame', swap_rgb=True, encoding='rgb8')
+    depthMsg = Mat2Image(frame_id='/camera_rgb_optical_frame', encoding='mono16')
     graph += [ source['depth'] >> depthMsg[:],
                source['image'] >> rgbMsg[:] ]
 
@@ -154,7 +154,7 @@ def create_capture_plasm(bag_name, angle_thresh, segmentation_cell, n_desired=72
                pose_filter['T'] >> masker['T'] ]
 
     # publish the mask
-    maskMsg = Mat2Image(frame_id='/camera_rgb_optical_frame', encoding='8UC1')
+    maskMsg = Mat2Image(frame_id='/camera_rgb_optical_frame', encoding='mono8')
     graph += [ masker['mask'] >> maskMsg[:] ]
 
     camera2cv = CameraModelToCv()


### PR DESCRIPTION
@vrabaud ROS doesn't seem to like "8UC1" very much and would not display the mask image. Using "mono8" seems more ROS-friendly.

Also blue and green were swapped after my last PR #23, that is now fixed. "bgr8"->"rgb8"

Sorry about that. It should be fine this time.
Cheers,
Jimmy
